### PR TITLE
fix: error handling in search_by#lemon_sours_controller

### DIFF
--- a/app/controllers/api/v1/lemon_sours_controller.rb
+++ b/app/controllers/api/v1/lemon_sours_controller.rb
@@ -27,7 +27,11 @@ class Api::V1::LemonSoursController < ApplicationController
 
   def search_by
     lemon_sours = LemonSour.displayed_based_on(search_sours_params)
-    render json: lemon_sours, status: :ok
+    if lemon_sours != []
+      render json: lemon_sours, status: :ok
+    else
+      render json: { error_message: "該当するデータがありません" }, status: :not_found
+    end
   end
 
   private

--- a/spec/requests/lemon_sours_request_spec.rb
+++ b/spec/requests/lemon_sours_request_spec.rb
@@ -49,13 +49,25 @@ RSpec.describe "Api::v1::LemonSours", type: :request do
     end
 
     context "GET /lemon_sours/search_by" do
-      it "クエリパラメータの指定のとおりにデータが取得される" do
-        params = { manufacturer: "キリン", ingredient: "すべて", order: "度数の高い順" }
-        get("/api/v1/lemon_sours/search_by", params: params)
-        json = JSON.parse(response.body)
-        expect(response.status).to eq 200
-        expect(json.length).to eq 2
-        expect([json[0]["name"], json[1]["name"]]).to eq [hyoketu_strong.name, hyoketu.name]
+      context "指定されたクエリパラメータに該当するデータがあれば、" do
+        it "指定のとおりにデータが取得される" do
+          params = { manufacturer: "キリン", ingredient: "すべて", order: "度数の高い順" }
+          get("/api/v1/lemon_sours/search_by", params: params)
+          json = JSON.parse(response.body)
+          expect(response.status).to eq 200
+          expect(json.length).to eq 2
+          expect([json[0]["name"], json[1]["name"]]).to eq [hyoketu_strong.name, hyoketu.name]
+        end
+      end
+
+      context "指定されたクエリパラメータに該当するデータがなければ、" do
+        it "リクエストに失敗する" do
+          params = { manufacturer: "宝酒造", ingredient: "すべて", order: "度数の高い順" }
+          get("/api/v1/lemon_sours/search_by", params: params)
+          json = JSON.parse(response.body)
+          expect(response.status).to eq 404
+          expect(json["error_message"]).to eq "該当するデータがありません"
+        end
       end
     end
   end


### PR DESCRIPTION
フロントの実装に伴い、バックのエラーハンドリングを見直し。